### PR TITLE
[Server] Add unhandled-exception middleware returning 429 with Retry-After: 30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,5 @@ dotnet-tools.json
 /build/
 /coverage/
 node_modules
+
+.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -338,7 +338,7 @@ src/Data
 # Mac files
 .DS_Store
 
-# Dotnet 
+# Dotnet
 .dotnet/
 
 # Jetbrains
@@ -372,5 +372,3 @@ dotnet-tools.json
 /build/
 /coverage/
 node_modules
-
-.pre-commit-config.yaml

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- Unhandled exception middleware returning HTTP 429 with Retry-After: 30 so clients back off during transient upstream failures
 ### Fixed
 ### Changed
 - Dependencies - Updated Figgle to 0.6.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Dependencies - Updated System.Interactive.Async to 7.0.1
 - Dependencies - Updated Microsoft.Extensions to 10.0.7
 - Dependencies - Updated Credfeto.Version.Information.Generator to 1.0.124.1183
+- Dependencies - Updated FunFair.Test.Common to 6.2.23.2204
 - Dependencies - Updated SonarAnalyzer.CSharp to 10.25.0.139117
 - Dependencies - Updated Credfeto.Date to 1.1.151.1695
 - Dependencies - Updated Credfeto.Docker.HealthCheck.Http.Client to 0.0.64.749

--- a/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
@@ -56,7 +56,7 @@
     <ProjectReference Include="..\Credfeto.Aur.Mirror.Cache\Credfeto.Aur.Mirror.Cache.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FunFair.Test.Common" Version="6.2.23.2204" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.24.2242" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
@@ -67,7 +67,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.24.2242" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Cache.Tests/Credfeto.Aur.Mirror.Cache.Tests.csproj
@@ -51,6 +51,7 @@
     <!-- error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
+  <Import Project="$(SolutonDir)UnitTests.props" Condition="Exists('$(SolutonDir)UnitTests.props')"/>
   <ItemGroup>
     <ProjectReference Include="..\Credfeto.Aur.Mirror.Cache\Credfeto.Aur.Mirror.Cache.csproj" />
   </ItemGroup>

--- a/src/Credfeto.Aur.Mirror.Cache.Tests/Services/LocalAurMetadataTests.cs
+++ b/src/Credfeto.Aur.Mirror.Cache.Tests/Services/LocalAurMetadataTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;

--- a/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
@@ -41,6 +41,7 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <WarningsAsErrors />
   </PropertyGroup>
+  <Import Project="$(SolutonDir)UnitTests.props" Condition="Exists('$(SolutonDir)UnitTests.props')"/>
   <ItemGroup>
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />

--- a/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Git.Tests/Credfeto.Aur.Mirror.Git.Tests.csproj
@@ -56,7 +56,7 @@
     <ProjectReference Include="..\Credfeto.Aur.Mirror.Git\Credfeto.Aur.Mirror.Git.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FunFair.Test.Common" Version="6.2.23.2204" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.24.2242" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
@@ -67,7 +67,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.24.2242" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
@@ -56,7 +56,7 @@
     <ProjectReference Include="..\Credfeto.Aur.Mirror.Rpc\Credfeto.Aur.Mirror.Rpc.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FunFair.Test.Common" Version="6.2.23.2204" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.24.2242" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
@@ -67,7 +67,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.24.2242" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
@@ -41,6 +41,7 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <WarningsAsErrors />
   </PropertyGroup>
+  <Import Project="$(SolutonDir)UnitTests.props" Condition="Exists('$(SolutonDir)UnitTests.props')"/>
   <ItemGroup>
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />

--- a/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
+++ b/src/Credfeto.Aur.Mirror.Rpc.Tests/Credfeto.Aur.Mirror.Rpc.Tests.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.124.1183" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.42.1940" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.23.2204" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.74" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Aur.Mirror.Server/AppJsonContext.cs
+++ b/src/Credfeto.Aur.Mirror.Server/AppJsonContext.cs
@@ -13,6 +13,7 @@ namespace Credfeto.Aur.Mirror.Server;
     WriteIndented = false,
     IncludeFields = false
 )]
+[JsonSerializable(typeof(ErrorDto))]
 [JsonSerializable(typeof(PongDto))]
 [JsonSerializable(typeof(RpcResponse))]
 [JsonSerializable(typeof(SearchResult))]

--- a/src/Credfeto.Aur.Mirror.Server/ErrorDto.cs
+++ b/src/Credfeto.Aur.Mirror.Server/ErrorDto.cs
@@ -1,0 +1,6 @@
+using System.Diagnostics;
+
+namespace Credfeto.Aur.Mirror.Server;
+
+[DebuggerDisplay("Error: {Error}")]
+internal sealed record ErrorDto(string Error);

--- a/src/Credfeto.Aur.Mirror.Server/Middleware/LoggingExtensions/UnhandledExceptionMiddlewareLoggingExtensions.cs
+++ b/src/Credfeto.Aur.Mirror.Server/Middleware/LoggingExtensions/UnhandledExceptionMiddlewareLoggingExtensions.cs
@@ -7,4 +7,7 @@ internal static partial class UnhandledExceptionMiddlewareLoggingExtensions
 {
     [LoggerMessage(LogLevel.Error, EventId = 1, Message = "Unhandled exception in request pipeline")]
     public static partial void UnhandledException(this ILogger logger, Exception exception);
+
+    [LoggerMessage(LogLevel.Debug, EventId = 2, Message = "Client disconnected before error response could be sent")]
+    public static partial void ClientDisconnectedDuringErrorResponse(this ILogger logger, Exception exception);
 }

--- a/src/Credfeto.Aur.Mirror.Server/Middleware/LoggingExtensions/UnhandledExceptionMiddlewareLoggingExtensions.cs
+++ b/src/Credfeto.Aur.Mirror.Server/Middleware/LoggingExtensions/UnhandledExceptionMiddlewareLoggingExtensions.cs
@@ -1,0 +1,10 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Aur.Mirror.Server.Middleware.LoggingExtensions;
+
+internal static partial class UnhandledExceptionMiddlewareLoggingExtensions
+{
+    [LoggerMessage(LogLevel.Error, EventId = 1, Message = "Unhandled exception in request pipeline")]
+    public static partial void UnhandledException(this ILogger logger, Exception exception);
+}

--- a/src/Credfeto.Aur.Mirror.Server/Middleware/UnhandledExceptionMiddleware.cs
+++ b/src/Credfeto.Aur.Mirror.Server/Middleware/UnhandledExceptionMiddleware.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Credfeto.Aur.Mirror.Server.Middleware.LoggingExtensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Aur.Mirror.Server.Middleware;
+
+public sealed class UnhandledExceptionMiddleware
+{
+    private const int RetryAfterSeconds = 30;
+    private readonly ILogger _logger;
+    private readonly RequestDelegate _next;
+
+    public UnhandledExceptionMiddleware(RequestDelegate next, ILogger<UnhandledExceptionMiddleware> logger)
+    {
+        this._next = next;
+        this._logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await this._next(context);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            this._logger.UnhandledException(exception);
+
+            if (context.Response.HasStarted)
+            {
+                return;
+            }
+
+            context.Response.Clear();
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            context.Response.Headers.Append(
+                key: "Retry-After",
+                value: RetryAfterSeconds.ToString(CultureInfo.InvariantCulture)
+            );
+            context.Response.ContentType = "application/json";
+
+            byte[] body = JsonSerializer.SerializeToUtf8Bytes(
+                value: new ErrorDto("Service temporarily unavailable. Please retry later."),
+                jsonTypeInfo: AppJsonContext.Default.ErrorDto
+            );
+
+            await context.Response.Body.WriteAsync(buffer: body, cancellationToken: context.RequestAborted);
+        }
+    }
+}

--- a/src/Credfeto.Aur.Mirror.Server/Middleware/UnhandledExceptionMiddleware.cs
+++ b/src/Credfeto.Aur.Mirror.Server/Middleware/UnhandledExceptionMiddleware.cs
@@ -11,6 +11,7 @@ namespace Credfeto.Aur.Mirror.Server.Middleware;
 public sealed class UnhandledExceptionMiddleware
 {
     private const int RetryAfterSeconds = 30;
+    private static readonly ErrorDto ErrorResponse = new("Service temporarily unavailable. Please retry later.");
     private readonly ILogger _logger;
     private readonly RequestDelegate _next;
 
@@ -44,11 +45,19 @@ public sealed class UnhandledExceptionMiddleware
             context.Response.ContentType = "application/json";
 
             byte[] body = JsonSerializer.SerializeToUtf8Bytes(
-                value: new ErrorDto("Service temporarily unavailable. Please retry later."),
+                value: ErrorResponse,
                 jsonTypeInfo: AppJsonContext.Default.ErrorDto
             );
 
-            await context.Response.Body.WriteAsync(buffer: body, cancellationToken: context.RequestAborted);
+            try
+            {
+                await context.Response.Body.WriteAsync(buffer: body, cancellationToken: context.RequestAborted);
+            }
+            catch (Exception writeException)
+                when (writeException is OperationCanceledException or System.IO.IOException)
+            {
+                this._logger.ClientDisconnectedDuringErrorResponse(writeException);
+            }
         }
     }
 }

--- a/src/Credfeto.Aur.Mirror.Server/Program.cs
+++ b/src/Credfeto.Aur.Mirror.Server/Program.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Aur.Mirror.Models.AurRpc;
 using Credfeto.Aur.Mirror.Server.Helpers;
+using Credfeto.Aur.Mirror.Server.Middleware;
 using Credfeto.Docker.HealthCheck.Http.Client;
 using Microsoft.AspNetCore.Builder;
 
@@ -101,6 +102,8 @@ public static class Program
     private static WebApplication AddMiddleware(WebApplication application)
     {
         WebApplication app = (WebApplication)application.UseForwardedHeaders();
+
+        app.UseMiddleware<UnhandledExceptionMiddleware>();
 
         return app.ConfigureEndpoints();
     }


### PR DESCRIPTION
## Summary

- Adds `UnhandledExceptionMiddleware` that catches all non-cancellation exceptions in the ASP.NET request pipeline and returns HTTP 429 with `Retry-After: 30` and a sanitised JSON error body
- Adds `ErrorDto` record (source-generated JSON) used by the middleware response
- Adds `UnhandledExceptionMiddlewareLoggingExtensions` for structured Error-level logging
- Removes `.pre-commit-config.yaml` from `.gitignore` — the file is tracked and the ignore entry was blocking the `check-no-ignored-files` pre-commit hook on all branches

## Test plan

- [x] Build passes with no warnings (`dotnet build --no-incremental -warnaserror`)
- [x] All 12 tests pass (`dotnet test`)
- [x] Pre-commit hooks pass (buildcheck, formatter, tests)
- [ ] Manual: trigger a `GitException` (e.g. point at an unreachable upstream) and verify response is 429 with `Retry-After: 30`

Closes #38